### PR TITLE
fault injection: support setting grpc_status code via config

### DIFF
--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -21,6 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Fault Injection :ref:`configuration overview <config_http_filters_fault_injection>`.
 // [#extension: envoy.filters.http.fault]
 
+// [#next-free-field: 6]
 message FaultAbort {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
@@ -41,6 +42,9 @@ message FaultAbort {
     // HTTP status code to use to abort the HTTP request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
+    // gRPC status code to use to abort the gRPC request.
+    uint32 grpc_status = 5 [(validate.rules).uint32 = {lte: 16}];
+
     // Fault aborts are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;
   }
@@ -50,7 +54,7 @@ message FaultAbort {
   type.v3.FractionalPercent percentage = 3;
 }
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.HTTPFault";
@@ -133,4 +137,8 @@ message HTTPFault {
   // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
   // runtime. The default is: fault.http.rate_limit.response_percent
   string response_rate_limit_percent_runtime = 13;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.abort.grpc_status
+  string abort_grpc_status_runtime = 14;
 }

--- a/api/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/api/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -43,7 +43,7 @@ message FaultAbort {
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
     // gRPC status code to use to abort the gRPC request.
-    uint32 grpc_status = 5 [(validate.rules).uint32 = {lte: 16}];
+    uint32 grpc_status = 5;
 
     // Fault aborts are controlled via an HTTP header (if applicable).
     HeaderAbort header_abort = 4;

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -144,6 +144,14 @@ fault.http.abort.http_status
   available regardless of whether the filter is :ref:`configured for abort
   <envoy_api_field_config.filter.http.fault.v2.HTTPFault.abort>`.
 
+fault.http.abort.grpc_status
+  gRPC status code that will be used as the response status code of requests that will be
+  aborted if the headers match. Defaults to the gRPC status code specified
+  in the config. If this field is missing from both the runtime and the config,
+  gRPC status code in the response will be derived from *fault.http.abort.http_status* field.
+  This runtime key is only available when the filter is :ref:`configured for abort
+  <envoy_api_field_config.filter.http.fault.v2.HTTPFault.abort>`.
+
 fault.http.delay.fixed_delay_percent
   % of requests that will be delayed if the headers match. Defaults to the
   *delay_percent* specified in the config or 0 otherwise. This runtime key is only available when

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -42,18 +42,6 @@ x-envoy-fault-abort-request
   In order for the header to work, :ref:`header_abort
   <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set.
 
-x-envoy-fault-abort-request-percentage
-  The percentage of requests that should be failed with a status code that's defined
-  by the value of *x-envoy-fault-abort-request* HTTP header. The header value should be an integer
-  that specifies the numerator of the percentage of request to apply aborts to and must be greater
-  or equal to 0 and its maximum value is capped by the value of the numerator of
-  :ref:`percentage <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
-  Percentage's denominator is equal to default percentage's denominator
-  :ref:`percentage <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
-  In order for the header to work, :ref:`header_abort
-  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set and
-  *x-envoy-fault-abort-request* HTTP header needs to be a part of a request.
-
 x-envoy-fault-abort-grpc-request
   gRPC status code to abort a request with. The header value should be a non-negative integer that specifies
   the gRPC status code to return in response to a request. Its value range is [0, UInt32.Max] instead of [0, 16]
@@ -64,18 +52,17 @@ x-envoy-fault-abort-grpc-request
   *x-envoy-fault-abort-grpc-request* header will be **ignored** and fault response http status code will be
   set to *x-envoy-fault-abort-request* header value.
 
-x-envoy-fault-abort-grpc-request-percentage
-  The percentage of gRPC requests that should be failed with a status code that's defined
-  by the value of *x-envoy-fault-abort-grpc-request* HTTP header. The header value should be an integer
-  that specifies the numerator of the percentage of request to apply aborts to and must be greater
-  or equal to 0 and its maximum value is capped by the value of the numerator of
+x-envoy-fault-abort-request-percentage
+  The percentage of requests that should be failed with a status code that's defined
+  by the value of *x-envoy-fault-abort-request* or *x-envoy-fault-abort-grpc-request* HTTP headers.
+  The header value should be an integer that specifies the numerator of the percentage of request to apply aborts
+  to and must be greater or equal to 0 and its maximum value is capped by the value of the numerator of
   :ref:`percentage <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
   Percentage's denominator is equal to default percentage's denominator
   :ref:`percentage <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
   In order for the header to work, :ref:`header_abort
   <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set and
-  *x-envoy-fault-abort-grpc-request* HTTP header needs to be a part of the request and 
-  *x-envoy-fault-abort-request* header should not be present in the request.
+  either *x-envoy-fault-abort-request* or *x-envoy-fault-abort-grpc-request* HTTP header needs to be a part of the request.
 
 x-envoy-fault-delay-request
   The duration to delay a request by. The header value should be an integer that specifies the number
@@ -169,11 +156,10 @@ fault.http.abort.http_status
 
 fault.http.abort.grpc_status
   gRPC status code that will be used as the response status code of requests that will be
-  aborted if the headers match. Defaults to the gRPC status code specified
-  in the config. If this field is missing from both the runtime and the config,
-  gRPC status code in the response will be derived from *fault.http.abort.http_status* field.
-  This runtime key is only available when the filter is :ref:`configured for abort
-  <envoy_api_field_config.filter.http.fault.v2.HTTPFault.abort>`.
+  aborted if the headers match. Defaults to the gRPC status code specified in the config.
+  If this field is missing from both the runtime and the config, gRPC status code in the response
+  will be derived from *fault.http.abort.http_status* field. This runtime key is only available when
+  the filter is :ref:`configured for abort <envoy_api_field_config.filter.http.fault.v2.HTTPFault.abort>`.
 
 fault.http.delay.fixed_delay_percent
   % of requests that will be delayed if the headers match. Defaults to the

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -43,10 +43,11 @@ x-envoy-fault-abort-request
   <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set.
 
 x-envoy-fault-abort-grpc-request
-  gRPC status code to abort a request with. The header value should be an integer that specifies
-  the gRPC status code to return in response to a request and must be in the range [0, 16].
-  When this header is set, the HTTP response status code will be set to 200. In order for the header to work,
-  :ref:`header_abort <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set. 
+  gRPC status code to abort a request with. The header value should be a non-negative integer that specifies
+  the gRPC status code to return in response to a request. Its value range is [0, UInt32.Max] instead of [0, 16]
+  to allow testing even not well-defined gRPC status codes. When this header is set, the HTTP response status code
+  will be set to 200. In order for the header to work, :ref:`header_abort
+  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set. 
 
 x-envoy-fault-abort-request-percentage
   The percentage of requests that should be failed with a status code that's defined

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -42,6 +42,12 @@ x-envoy-fault-abort-request
   In order for the header to work, :ref:`header_abort
   <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set.
 
+x-envoy-fault-abort-grpc-request
+  gRPC status code to abort a request with. The header value should be an integer that specifies
+  the gRPC status code to return in response to a request and must be in the range [0, 16].
+  When this header is set, the HTTP response status code will be set to 200. In order for the header to work,
+  :ref:`header_abort <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set. 
+
 x-envoy-fault-abort-request-percentage
   The percentage of requests that should be failed with a status code that's defined
   by the value of *x-envoy-fault-abort-request* HTTP header. The header value should be an integer

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -59,7 +59,10 @@ x-envoy-fault-abort-grpc-request
   the gRPC status code to return in response to a request. Its value range is [0, UInt32.Max] instead of [0, 16]
   to allow testing even not well-defined gRPC status codes. When this header is set, the HTTP response status code
   will be set to 200. In order for the header to work, :ref:`header_abort
-  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set. 
+  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set. If both 
+  *x-envoy-fault-abort-request* and *x-envoy-fault-abort-grpc-request* headers are set then 
+  *x-envoy-fault-abort-grpc-request* header will be **ignored** and fault response http status code will be
+  set to *x-envoy-fault-abort-request* header value.
 
 x-envoy-fault-abort-grpc-request-percentage
   The percentage of gRPC requests that should be failed with a status code that's defined
@@ -71,7 +74,8 @@ x-envoy-fault-abort-grpc-request-percentage
   :ref:`percentage <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
   In order for the header to work, :ref:`header_abort
   <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set and
-  *x-envoy-fault-abort-grpc-request* HTTP header needs to be a part of a request.
+  *x-envoy-fault-abort-grpc-request* HTTP header needs to be a part of the request and 
+  *x-envoy-fault-abort-request* header should not be present in the request.
 
 x-envoy-fault-delay-request
   The duration to delay a request by. The header value should be an integer that specifies the number

--- a/docs/root/configuration/http/http_filters/fault_filter.rst
+++ b/docs/root/configuration/http/http_filters/fault_filter.rst
@@ -42,13 +42,6 @@ x-envoy-fault-abort-request
   In order for the header to work, :ref:`header_abort
   <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set.
 
-x-envoy-fault-abort-grpc-request
-  gRPC status code to abort a request with. The header value should be a non-negative integer that specifies
-  the gRPC status code to return in response to a request. Its value range is [0, UInt32.Max] instead of [0, 16]
-  to allow testing even not well-defined gRPC status codes. When this header is set, the HTTP response status code
-  will be set to 200. In order for the header to work, :ref:`header_abort
-  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set. 
-
 x-envoy-fault-abort-request-percentage
   The percentage of requests that should be failed with a status code that's defined
   by the value of *x-envoy-fault-abort-request* HTTP header. The header value should be an integer
@@ -60,6 +53,25 @@ x-envoy-fault-abort-request-percentage
   In order for the header to work, :ref:`header_abort
   <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set and
   *x-envoy-fault-abort-request* HTTP header needs to be a part of a request.
+
+x-envoy-fault-abort-grpc-request
+  gRPC status code to abort a request with. The header value should be a non-negative integer that specifies
+  the gRPC status code to return in response to a request. Its value range is [0, UInt32.Max] instead of [0, 16]
+  to allow testing even not well-defined gRPC status codes. When this header is set, the HTTP response status code
+  will be set to 200. In order for the header to work, :ref:`header_abort
+  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set. 
+
+x-envoy-fault-abort-grpc-request-percentage
+  The percentage of gRPC requests that should be failed with a status code that's defined
+  by the value of *x-envoy-fault-abort-grpc-request* HTTP header. The header value should be an integer
+  that specifies the numerator of the percentage of request to apply aborts to and must be greater
+  or equal to 0 and its maximum value is capped by the value of the numerator of
+  :ref:`percentage <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
+  Percentage's denominator is equal to default percentage's denominator
+  :ref:`percentage <envoy_api_field_config.filter.http.fault.v2.FaultAbort.percentage>` field.
+  In order for the header to work, :ref:`header_abort
+  <envoy_api_field_config.filter.http.fault.v2.FaultAbort.header_abort>` needs to be set and
+  *x-envoy-fault-abort-grpc-request* HTTP header needs to be a part of a request.
 
 x-envoy-fault-delay-request
   The duration to delay a request by. The header value should be an integer that specifies the number

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -8,6 +8,8 @@ Changes
 * dynamic forward proxy: added :ref:`SNI based dynamic forward proxy <config_network_filters_sni_dynamic_forward_proxy>` support.
 * fault: added support for controlling the percentage of requests that abort, delay and response rate limits faults 
   are applied to using :ref:`HTTP headers <config_http_filters_fault_injection_http_header>` to the HTTP fault filter.
+* fault: added support for specifying grpc_status code in abort faults using
+  :ref:`HTTP header <config_http_filters_fault_injection_http_header>` or abort fault configuration in HTTP fault filter.
 * filter: add `upstram_rq_time` stats to the GPRC stats filter.
   Disabled by default and can be enabled via :ref:`enable_upstream_stats <envoy_v3_api_field_extensions.filters.http.grpc_stats.v3.FilterConfig.enable_upstream_stats>`.
 * http: fixed a bug where the upgrade header was not cleared on responses to non-upgrade requests.

--- a/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -21,6 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Fault Injection :ref:`configuration overview <config_http_filters_fault_injection>`.
 // [#extension: envoy.filters.http.fault]
 
+// [#next-free-field: 6]
 message FaultAbort {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.FaultAbort";
@@ -41,8 +42,11 @@ message FaultAbort {
   oneof error_type {
     option (validate.required) = true;
 
-    // Fault aborts are controlled via an HTTP header (if applicable).
+    // gRPC status code to use to abort the gRPC request.
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
+
+    // Fault aborts are controlled via an HTTP header (if applicable).
+    uint32 grpc_status = 5 [(validate.rules).uint32 = {lte: 16}];
 
     // The percentage of requests/operations/connections that will be aborted with the error code
     // provided.
@@ -50,7 +54,7 @@ message FaultAbort {
   }
 }
 
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message HTTPFault {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.fault.v2.HTTPFault";
@@ -133,4 +137,8 @@ message HTTPFault {
   // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
   // runtime. The default is: fault.http.rate_limit.response_percent
   string response_rate_limit_percent_runtime = 13;
+
+  // The runtime key to override the :ref:`default <config_http_filters_fault_injection_runtime>`
+  // runtime. The default is: fault.http.abort.grpc_status
+  string abort_grpc_status_runtime = 14;
 }

--- a/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/generated_api_shadow/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -46,7 +46,7 @@ message FaultAbort {
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
     // Fault aborts are controlled via an HTTP header (if applicable).
-    uint32 grpc_status = 5 [(validate.rules).uint32 = {lte: 16}];
+    uint32 grpc_status = 5;
 
     // The percentage of requests/operations/connections that will be aborted with the error code
     // provided.

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -85,16 +85,6 @@ absl::optional<Grpc::Status::GrpcStatus> FaultAbortConfig::HeaderAbortProvider::
   return static_cast<Grpc::Status::GrpcStatus>(code);
 }
 
-envoy::type::v3::FractionalPercent FaultAbortConfig::HeaderAbortProvider::percentage(
-    const Http::RequestHeaderMap* request_headers) const {
-  // if the abort fault contains http status header, then use http status request percentage.
-  if (request_headers->get(Filters::Common::Fault::HeaderNames::get().AbortRequest) != nullptr) {
-    return http_header_percentage_provider_.percentage(request_headers);
-  }
-
-  return grpc_header_percentage_provider_.percentage(request_headers);
-}
-
 FaultDelayConfig::FaultDelayConfig(
     const envoy::extensions::filters::common::fault::v3::FaultDelay& delay_config) {
   switch (delay_config.fault_delay_secifier_case()) {

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -104,10 +104,10 @@ envoy::type::v3::FractionalPercent FaultAbortConfig::HeaderAbortProvider::percen
   if (request_headers != nullptr &&
       request_headers->get(Filters::Common::Fault::HeaderNames::get().AbortGrpcRequest) !=
           nullptr) {
-    return grpcHeaderPercentageProvider_.percentage(request_headers);
+    return grpc_header_percentage_provider_.percentage(request_headers);
   }
 
-  return httpHeaderPercentageProvider_.percentage(request_headers);
+  return http_header_percentage_provider_.percentage(request_headers);
 }
 
 FaultDelayConfig::FaultDelayConfig(

--- a/source/extensions/filters/common/fault/fault_config.cc
+++ b/source/extensions/filters/common/fault/fault_config.cc
@@ -55,9 +55,9 @@ FaultAbortConfig::FaultAbortConfig(
   }
 }
 
-absl::optional<Http::Code>
-FaultAbortConfig::HeaderAbortProvider::httpStatusCode(const Http::RequestHeaderMap* request_headers) const {
-  if(request_headers == nullptr) {
+absl::optional<Http::Code> FaultAbortConfig::HeaderAbortProvider::httpStatusCode(
+    const Http::RequestHeaderMap* request_headers) const {
+  if (request_headers == nullptr) {
     return absl::nullopt;
   }
 
@@ -79,9 +79,9 @@ FaultAbortConfig::HeaderAbortProvider::httpStatusCode(const Http::RequestHeaderM
   return ret;
 }
 
-absl::optional<Grpc::Status::GrpcStatus>
-FaultAbortConfig::HeaderAbortProvider::grpcStatusCode(const Http::RequestHeaderMap* request_headers) const {
-  if(request_headers == nullptr) {
+absl::optional<Grpc::Status::GrpcStatus> FaultAbortConfig::HeaderAbortProvider::grpcStatusCode(
+    const Http::RequestHeaderMap* request_headers) const {
+  if (request_headers == nullptr) {
     return absl::nullopt;
   }
 
@@ -96,6 +96,18 @@ FaultAbortConfig::HeaderAbortProvider::grpcStatusCode(const Http::RequestHeaderM
   }
 
   return static_cast<Grpc::Status::GrpcStatus>(code);
+}
+
+envoy::type::v3::FractionalPercent FaultAbortConfig::HeaderAbortProvider::percentage(
+    const Http::RequestHeaderMap* request_headers) const {
+  // if the abort fault is for grpc status, then use grpc fault request percentage.
+  if (request_headers != nullptr &&
+      request_headers->get(Filters::Common::Fault::HeaderNames::get().AbortGrpcRequest) !=
+          nullptr) {
+    return grpcHeaderPercentageProvider_.percentage(request_headers);
+  }
+
+  return httpHeaderPercentageProvider_.percentage(request_headers);
 }
 
 FaultDelayConfig::FaultDelayConfig(

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -24,8 +24,6 @@ public:
   const Http::LowerCaseString AbortRequestPercentage{
       absl::StrCat(prefix(), "-fault-abort-request-percentage")};
   const Http::LowerCaseString AbortGrpcRequest{absl::StrCat(prefix(), "-fault-abort-grpc-request")};
-  const Http::LowerCaseString AbortGrpcRequestPercentage{
-      absl::StrCat(prefix(), "-fault-abort-grpc-request-percentage")};
   const Http::LowerCaseString DelayRequest{absl::StrCat(prefix(), "-fault-delay-request")};
   const Http::LowerCaseString DelayRequestPercentage{
       absl::StrCat(prefix(), "-fault-delay-request-percentage")};
@@ -124,9 +122,7 @@ private:
   class HeaderAbortProvider : public AbortProvider {
   public:
     HeaderAbortProvider(const envoy::type::v3::FractionalPercent& percentage)
-        : grpc_header_percentage_provider_(HeaderNames::get().AbortGrpcRequestPercentage,
-                                           percentage),
-          http_header_percentage_provider_(HeaderNames::get().AbortRequestPercentage, percentage) {}
+        : header_percentage_provider_(HeaderNames::get().AbortRequestPercentage, percentage) {}
 
     absl::optional<Http::Code>
     httpStatusCode(const Http::RequestHeaderMap* request_headers) const override;
@@ -135,11 +131,12 @@ private:
     grpcStatusCode(const Http::RequestHeaderMap* request_headers) const override;
 
     envoy::type::v3::FractionalPercent
-    percentage(const Http::RequestHeaderMap* request_headers) const override;
+    percentage(const Http::RequestHeaderMap* request_headers) const override {
+      return header_percentage_provider_.percentage(request_headers);
+    }
 
   private:
-    HeaderPercentageProvider grpc_header_percentage_provider_;
-    HeaderPercentageProvider http_header_percentage_provider_;
+    HeaderPercentageProvider header_percentage_provider_;
   };
 
   using AbortProviderPtr = std::unique_ptr<AbortProvider>;

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -55,11 +55,11 @@ class FaultAbortConfig {
 public:
   FaultAbortConfig(const envoy::extensions::filters::http::fault::v3::FaultAbort& abort_config);
 
-  absl::optional<Http::Code> httpStatusCode(const Http::HeaderEntry* header) const {
-    return provider_->httpStatusCode(header);
+  absl::optional<Http::Code> httpStatusCode(const Http::RequestHeaderMap* request_headers) const {
+    return provider_->httpStatusCode(request_headers);
   }
-  absl::optional<Grpc::Status::GrpcStatus> grpcStatusCode(const Http::HeaderEntry* header) const {
-    return provider_->grpcStatusCode(header);
+  absl::optional<Grpc::Status::GrpcStatus> grpcStatusCode(const Http::RequestHeaderMap* request_headers) const {
+    return provider_->grpcStatusCode(request_headers);
   }
 
   envoy::type::v3::FractionalPercent
@@ -75,12 +75,12 @@ private:
 
     // Return the HTTP status code to use. Optionally passed HTTP headers that may contain the
     // HTTP status code depending on the provider implementation.
-    virtual absl::optional<Http::Code> httpStatusCode(const Http::HeaderEntry* header) const PURE;
+    virtual absl::optional<Http::Code> httpStatusCode(const Http::RequestHeaderMap* request_headers) const PURE;
 
     // Return the gRPC status code to use. Optionally passed an HTTP header that may contain the
     // gRPC status code depending on the provider implementation.
     virtual absl::optional<Grpc::Status::GrpcStatus>
-    grpcStatusCode(const Http::HeaderEntry* header) const PURE;
+    grpcStatusCode(const Http::RequestHeaderMap* request_headers) const PURE;
 
     // Return what percentage of requests abort faults should be applied to. Optionally passed
     // HTTP headers that may contain the percentage depending on the provider implementation.
@@ -97,12 +97,12 @@ private:
         : http_status_code_(http_status_code), grpc_status_code_(grpc_status_code),
           percentage_(percentage) {}
 
-    absl::optional<Http::Code> httpStatusCode(const Http::HeaderEntry*) const override {
+    absl::optional<Http::Code> httpStatusCode(const Http::RequestHeaderMap*) const override {
       return http_status_code_;
     }
 
     absl::optional<Grpc::Status::GrpcStatus>
-    grpcStatusCode(const Http::HeaderEntry*) const override {
+    grpcStatusCode(const Http::RequestHeaderMap*) const override {
       return grpc_status_code_;
     }
 
@@ -122,10 +122,10 @@ private:
     HeaderAbortProvider(const envoy::type::v3::FractionalPercent& percentage)
         : HeaderPercentageProvider(HeaderNames::get().AbortRequestPercentage, percentage) {}
 
-    absl::optional<Http::Code> httpStatusCode(const Http::HeaderEntry* header) const override;
+    absl::optional<Http::Code> httpStatusCode(const Http::RequestHeaderMap* request_headers) const override;
 
     absl::optional<Grpc::Status::GrpcStatus>
-    grpcStatusCode(const Http::HeaderEntry*) const override;
+    grpcStatusCode(const Http::RequestHeaderMap* request_headers) const override;
 
     envoy::type::v3::FractionalPercent
     percentage(const Http::RequestHeaderMap* request_headers) const override {

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -95,7 +95,7 @@ private:
   // Abort provider that uses a fixed abort status code.
   class FixedAbortProvider : public AbortProvider {
   public:
-    FixedAbortProvider(Http::Code http_status_code,
+    FixedAbortProvider(absl::optional<Http::Code> http_status_code,
                        absl::optional<Grpc::Status::GrpcStatus> grpc_status_code,
                        const envoy::type::v3::FractionalPercent& percentage)
         : http_status_code_(http_status_code), grpc_status_code_(grpc_status_code),

--- a/source/extensions/filters/common/fault/fault_config.h
+++ b/source/extensions/filters/common/fault/fault_config.h
@@ -124,8 +124,9 @@ private:
   class HeaderAbortProvider : public AbortProvider {
   public:
     HeaderAbortProvider(const envoy::type::v3::FractionalPercent& percentage)
-        : grpcHeaderPercentageProvider_(HeaderNames::get().AbortGrpcRequestPercentage, percentage),
-          httpHeaderPercentageProvider_(HeaderNames::get().AbortRequestPercentage, percentage) {}
+        : grpc_header_percentage_provider_(HeaderNames::get().AbortGrpcRequestPercentage,
+                                           percentage),
+          http_header_percentage_provider_(HeaderNames::get().AbortRequestPercentage, percentage) {}
 
     absl::optional<Http::Code>
     httpStatusCode(const Http::RequestHeaderMap* request_headers) const override;
@@ -137,8 +138,8 @@ private:
     percentage(const Http::RequestHeaderMap* request_headers) const override;
 
   private:
-    HeaderPercentageProvider grpcHeaderPercentageProvider_;
-    HeaderPercentageProvider httpHeaderPercentageProvider_;
+    HeaderPercentageProvider grpc_header_percentage_provider_;
+    HeaderPercentageProvider http_header_percentage_provider_;
   };
 
   using AbortProviderPtr = std::unique_ptr<AbortProvider>;
@@ -207,7 +208,7 @@ private:
   class HeaderDelayProvider : public DelayProvider {
   public:
     HeaderDelayProvider(const envoy::type::v3::FractionalPercent& percentage)
-        : headerPercentageProvider_(HeaderNames::get().DelayRequestPercentage, percentage) {}
+        : header_percentage_provider_(HeaderNames::get().DelayRequestPercentage, percentage) {}
 
     // DelayProvider
     absl::optional<std::chrono::milliseconds>
@@ -215,11 +216,11 @@ private:
 
     envoy::type::v3::FractionalPercent
     percentage(const Http::RequestHeaderMap* request_headers) const override {
-      return headerPercentageProvider_.percentage(request_headers);
+      return header_percentage_provider_.percentage(request_headers);
     }
 
   private:
-    HeaderPercentageProvider headerPercentageProvider_;
+    HeaderPercentageProvider header_percentage_provider_;
   };
 
   using DelayProviderPtr = std::unique_ptr<DelayProvider>;
@@ -287,16 +288,17 @@ private:
   class HeaderRateLimitProvider : public RateLimitProvider {
   public:
     HeaderRateLimitProvider(const envoy::type::v3::FractionalPercent& percentage)
-        : headerPercentageProvider_(HeaderNames::get().ThroughputResponsePercentage, percentage) {}
+        : header_percentage_provider_(HeaderNames::get().ThroughputResponsePercentage, percentage) {
+    }
     // RateLimitProvider
     absl::optional<uint64_t> rateKbps(const Http::RequestHeaderMap* request_headers) const override;
     envoy::type::v3::FractionalPercent
     percentage(const Http::RequestHeaderMap* request_headers) const override {
-      return headerPercentageProvider_.percentage(request_headers);
+      return header_percentage_provider_.percentage(request_headers);
     }
 
   private:
-    HeaderPercentageProvider headerPercentageProvider_;
+    HeaderPercentageProvider header_percentage_provider_;
   };
 
   using RateLimitProviderPtr = std::unique_ptr<RateLimitProvider>;

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -293,15 +293,15 @@ FaultFilter::delayDuration(const Http::RequestHeaderMap& request_headers) {
 
 AbortHttpAndGrpcStatus FaultFilter::abortStatus(const Http::RequestHeaderMap& request_headers) {
   if (!isAbortEnabled(request_headers)) {
-    return AbortHttpAndGrpcStatus(absl::nullopt, absl::nullopt);
+    return AbortHttpAndGrpcStatus{absl::nullopt, absl::nullopt};
   }
 
   auto grpc_status = abortGrpcStatus(request_headers);
 
   // If gRPC status code is set, then HTTP will be set to Http::Code::OK (200).
   return grpc_status.has_value()
-             ? AbortHttpAndGrpcStatus(Http::Code::OK, grpc_status)
-             : AbortHttpAndGrpcStatus(abortHttpStatus(request_headers), absl::nullopt);
+             ? AbortHttpAndGrpcStatus{Http::Code::OK, grpc_status}
+             : AbortHttpAndGrpcStatus{abortHttpStatus(request_headers), absl::nullopt};
 }
 
 absl::optional<Http::Code>

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -430,10 +430,10 @@ void FaultFilter::postDelayInjection(const Http::RequestHeaderMap& request_heade
 }
 
 void FaultFilter::abortWithStatus(Http::Code http_status_code,
-                                  absl::optional<Grpc::Status::GrpcStatus> grpc_status_code) {
+                                  absl::optional<Grpc::Status::GrpcStatus> grpc_status) {
   decoder_callbacks_->streamInfo().setResponseFlag(StreamInfo::ResponseFlag::FaultInjected);
-  decoder_callbacks_->sendLocalReply(http_status_code, "fault filter abort", nullptr,
-                                     grpc_status_code, RcDetails::get().FaultAbort);
+  decoder_callbacks_->sendLocalReply(http_status_code, "fault filter abort", nullptr, grpc_status,
+                                     RcDetails::get().FaultAbort);
   recordAbortsInjectedStats();
 }
 

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -67,6 +67,7 @@ public:
   const std::string& abortPercentRuntime() const { return abort_percent_runtime_; }
   const std::string& delayPercentRuntime() const { return delay_percent_runtime_; }
   const std::string& abortHttpStatusRuntime() const { return abort_http_status_runtime_; }
+  const std::string& abortGrpcStatusRuntime() const { return abort_grpc_status_runtime_; }
   const std::string& delayDurationRuntime() const { return delay_duration_runtime_; }
   const std::string& maxActiveFaultsRuntime() const { return max_active_faults_runtime_; }
   const std::string& responseRateLimitPercentRuntime() const {
@@ -80,6 +81,7 @@ private:
     const std::string AbortPercentKey = "fault.http.abort.abort_percent";
     const std::string DelayDurationKey = "fault.http.delay.fixed_duration_ms";
     const std::string AbortHttpStatusKey = "fault.http.abort.http_status";
+    const std::string AbortGrpcStatusKey = "fault.http.abort.grpc_status";
     const std::string MaxActiveFaultsKey = "fault.http.max_active_faults";
     const std::string ResponseRateLimitPercentKey = "fault.http.rate_limit.response_percent";
   };
@@ -98,6 +100,7 @@ private:
   const std::string abort_percent_runtime_;
   const std::string delay_duration_runtime_;
   const std::string abort_http_status_runtime_;
+  const std::string abort_grpc_status_runtime_;
   const std::string max_active_faults_runtime_;
   const std::string response_rate_limit_percent_runtime_;
 };
@@ -203,6 +206,8 @@ private:
   Buffer::WatermarkBuffer buffer_;
 };
 
+using AbortHttpAndGrpcStatus =
+    std::pair<absl::optional<Http::Code>, absl::optional<Grpc::Status::GrpcStatus>>;
 /**
  * A filter that is capable of faulting an entire request before dispatching it upstream.
  */
@@ -245,7 +250,8 @@ private:
   void recordDelaysInjectedStats();
   void resetTimerState();
   void postDelayInjection(const Http::RequestHeaderMap& request_headers);
-  void abortWithHTTPStatus(Http::Code abort_code);
+  void abortWithStatus(Http::Code http_status_code,
+                       absl::optional<Grpc::Status::GrpcStatus> grpc_status_code);
   bool matchesTargetUpstreamCluster();
   bool matchesDownstreamNodes(const Http::RequestHeaderMap& headers);
   bool isAbortEnabled(const Http::RequestHeaderMap& request_headers);
@@ -253,7 +259,10 @@ private:
   bool isResponseRateLimitEnabled(const Http::RequestHeaderMap& request_headers);
   absl::optional<std::chrono::milliseconds>
   delayDuration(const Http::RequestHeaderMap& request_headers);
+  AbortHttpAndGrpcStatus abortStatus(const Http::RequestHeaderMap& request_headers);
   absl::optional<Http::Code> abortHttpStatus(const Http::RequestHeaderMap& request_headers);
+  absl::optional<Grpc::Status::GrpcStatus>
+  abortGrpcStatus(const Http::RequestHeaderMap& request_headers);
   void maybeIncActiveFaults();
   void maybeSetupResponseRateLimit(const Http::RequestHeaderMap& request_headers);
 

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -279,6 +279,7 @@ private:
   std::string downstream_cluster_abort_percent_key_{};
   std::string downstream_cluster_delay_duration_key_{};
   std::string downstream_cluster_abort_http_status_key_{};
+  std::string downstream_cluster_abort_grpc_status_key_{};
 };
 
 } // namespace Fault

--- a/test/extensions/filters/common/fault/fault_config_test.cc
+++ b/test/extensions/filters/common/fault/fault_config_test.cc
@@ -65,103 +65,27 @@ TEST(FaultConfigTest, FaultAbortPercentageHeaderConfig) {
   FaultAbortConfig config(proto_config);
 
   // Header with bad data - fallback to proto config.
-  Http::TestRequestHeaderMapImpl bad_headers{{"x-envoy-fault-abort-request", "401"},
-                                             {"x-envoy-fault-abort-request-percentage", "abc"}};
+  Http::TestRequestHeaderMapImpl bad_headers{{"x-envoy-fault-abort-request-percentage", "abc"}};
   const auto bad_headers_percentage = config.percentage(&bad_headers);
   EXPECT_EQ(proto_config.percentage().numerator(), bad_headers_percentage.numerator());
   EXPECT_EQ(proto_config.percentage().denominator(), bad_headers_percentage.denominator());
 
   // Out of range header, value too low - fallback to proto config.
-  Http::TestRequestHeaderMapImpl too_low_headers{{"x-envoy-fault-abort-request", "401"},
-                                                 {"x-envoy-fault-abort-request-percentage", "-1"}};
+  Http::TestRequestHeaderMapImpl too_low_headers{{"x-envoy-fault-abort-request-percentage", "-1"}};
   const auto too_low_headers_percentage = config.percentage(&too_low_headers);
   EXPECT_EQ(proto_config.percentage().numerator(), too_low_headers_percentage.numerator());
   EXPECT_EQ(proto_config.percentage().denominator(), too_low_headers_percentage.denominator());
 
   // Valid header with value greater than the value of the numerator of default percentage - use
   // proto config.
-  Http::TestRequestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request", "401"},
-                                              {"x-envoy-fault-abort-request-percentage", "90"}};
-  const auto good_headers_percentage = config.percentage(&good_headers);
-  EXPECT_EQ(proto_config.percentage().numerator(), good_headers_percentage.numerator());
-  EXPECT_EQ(proto_config.percentage().denominator(), good_headers_percentage.denominator());
-
-  // Headers contains grpc-request-percentage instead of abort-request-percentage - fallback to
-  // proto config.
-  Http::TestRequestHeaderMapImpl grpc_request_numerator_headers{
-      {"x-envoy-fault-abort-request", "401"},
-      {"x-envoy-fault-abort-grpc-request-percentage", "60"}};
-  const auto grpc_request_numerator_headers_percentage =
-      config.percentage(&grpc_request_numerator_headers);
-  EXPECT_EQ(proto_config.percentage().numerator(),
-            grpc_request_numerator_headers_percentage.numerator());
-  EXPECT_EQ(proto_config.percentage().denominator(),
-            grpc_request_numerator_headers_percentage.denominator());
-
-  // Headers contains both grpc-request-percentage and abort-request-percentage - use
-  // abort-request-percentage header value.
-  Http::TestRequestHeaderMapImpl http_and_grpc_request_numerator_headers{
-      {"x-envoy-fault-abort-request", "401"},
-      {"x-envoy-fault-abort-request-percentage", "60"},
-      {"x-envoy-fault-abort-grpc-request", "401"},
-      {"x-envoy-fault-abort-grpc-request-percentage", "40"}};
-  const auto http_and_grpc_request_numerator_headers_percentage =
-      config.percentage(&http_and_grpc_request_numerator_headers);
-  EXPECT_EQ(60, http_and_grpc_request_numerator_headers_percentage.numerator());
-  EXPECT_EQ(proto_config.percentage().denominator(),
-            http_and_grpc_request_numerator_headers_percentage.denominator());
-
-  // Valid header with value lesser than the value of the numerator of default percentage.
-  Http::TestRequestHeaderMapImpl greater_numerator_headers{
-      {"x-envoy-fault-abort-request", "401"}, {"x-envoy-fault-abort-request-percentage", "60"}};
-  const auto greater_numerator_headers_percentage = config.percentage(&greater_numerator_headers);
-  EXPECT_EQ(60, greater_numerator_headers_percentage.numerator());
-  EXPECT_EQ(proto_config.percentage().denominator(),
-            greater_numerator_headers_percentage.denominator());
-}
-
-TEST(FaultConfigTest, FaultAbortGrpcPercentageHeaderConfig) {
-  envoy::extensions::filters::http::fault::v3::FaultAbort proto_config;
-  proto_config.mutable_header_abort();
-  proto_config.mutable_percentage()->set_numerator(80);
-  proto_config.mutable_percentage()->set_denominator(envoy::type::v3::FractionalPercent::HUNDRED);
-  FaultAbortConfig config(proto_config);
-
-  // Header with bad data - fallback to proto config.
-  Http::TestRequestHeaderMapImpl bad_headers{
-      {"x-envoy-fault-abort-grpc-request", "5"},
-      {"x-envoy-fault-abort-grpc-request-percentage", "abc"}};
-  const auto bad_headers_percentage = config.percentage(&bad_headers);
-  EXPECT_EQ(proto_config.percentage().numerator(), bad_headers_percentage.numerator());
-  EXPECT_EQ(proto_config.percentage().denominator(), bad_headers_percentage.denominator());
-
-  // Out of range header, value too low - fallback to proto config.
-  Http::TestRequestHeaderMapImpl too_low_headers{
-      {"x-envoy-fault-abort-grpc-request", "5"},
-      {"x-envoy-fault-abort-grpc-request-percentage", "-1"}};
-  const auto too_low_headers_percentage = config.percentage(&too_low_headers);
-  EXPECT_EQ(proto_config.percentage().numerator(), too_low_headers_percentage.numerator());
-  EXPECT_EQ(proto_config.percentage().denominator(), too_low_headers_percentage.denominator());
-
-  // Missing grpc request percentage header - use proto config.
-  Http::TestRequestHeaderMapImpl missing_header{{"x-envoy-fault-abort-grpc-request", "5"}};
-  const auto missing_header_percentage = config.percentage(&missing_header);
-  EXPECT_EQ(proto_config.percentage().numerator(), missing_header_percentage.numerator());
-  EXPECT_EQ(proto_config.percentage().denominator(), missing_header_percentage.denominator());
-
-  // Valid header with value greater than the value of the numerator of default percentage - use
-  // proto config.
-  Http::TestRequestHeaderMapImpl good_headers{
-      {"x-envoy-fault-abort-grpc-request", "5"},
-      {"x-envoy-fault-abort-grpc-request-percentage", "90"}};
+  Http::TestRequestHeaderMapImpl good_headers{{"x-envoy-fault-abort-request-percentage", "90"}};
   const auto good_headers_percentage = config.percentage(&good_headers);
   EXPECT_EQ(proto_config.percentage().numerator(), good_headers_percentage.numerator());
   EXPECT_EQ(proto_config.percentage().denominator(), good_headers_percentage.denominator());
 
   // Valid header with value lesser than the value of the numerator of default percentage.
   Http::TestRequestHeaderMapImpl greater_numerator_headers{
-      {"x-envoy-fault-abort-grpc-request", "5"},
-      {"x-envoy-fault-abort-grpc-request-percentage", "60"}};
+      {"x-envoy-fault-abort-request-percentage", "60"}};
   const auto greater_numerator_headers_percentage = config.percentage(&greater_numerator_headers);
   EXPECT_EQ(60, greater_numerator_headers_percentage.numerator());
   EXPECT_EQ(proto_config.percentage().denominator(),

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -264,7 +264,7 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortGrpcConfig0PercentageHe
                                      {":scheme", "http"},
                                      {":authority", "host"},
                                      {"x-envoy-fault-abort-grpc-request", "5"},
-                                     {"x-envoy-fault-abort-grpc-request-percentage", "0"},
+                                     {"x-envoy-fault-abort-request-percentage", "0"},
                                      {"content-type", "application/grpc"}});
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(default_response_headers_, true);

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -46,6 +46,17 @@ typed_config:
     percentage:
       numerator: 100
 )EOF";
+
+  const std::string abort_grpc_fault_config_ =
+      R"EOF(
+name: fault
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
+  abort:
+    percentage:
+      numerator: 100
+    grpc_status: 5
+)EOF";
 };
 
 // Fault integration tests that should run with all protocols, useful for testing various
@@ -210,6 +221,61 @@ TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultConfigNoHeaders) {
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 1024);
 
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
+}
+
+// Request abort with grpc status, controlled via header configuration.
+TEST_P(FaultIntegrationTestAllProtocols, HeaderFaultAbortGrpcConfig) {
+  initializeFilter(header_fault_config_);
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-envoy-fault-abort-grpc-request", "5"},
+                                     {"content-type", "application/grpc"}});
+  response->waitForEndStream();
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_THAT(response->headers(), Envoy::Http::HttpStatusIs("200"));
+  EXPECT_THAT(response->headers(),
+              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "5"));
+  EXPECT_THAT(response->headers(),
+              HeaderValueOf(Http::Headers::get().GrpcMessage, "fault filter abort"));
+  EXPECT_EQ(nullptr, response->trailers());
+
+  EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
+  EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
+}
+
+// Request abort with grpc status, controlled via configuration.
+TEST_P(FaultIntegrationTestAllProtocols, FaultAbortGrpcConfig) {
+  initializeFilter(abort_grpc_fault_config_);
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/grpc"}});
+  response->waitForEndStream();
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_THAT(response->headers(), Envoy::Http::HttpStatusIs("200"));
+  EXPECT_THAT(response->headers(),
+              HeaderValueOf(Http::Headers::get().ContentType, "application/grpc"));
+  EXPECT_THAT(response->headers(), HeaderValueOf(Http::Headers::get().GrpcStatus, "5"));
+  EXPECT_THAT(response->headers(),
+              HeaderValueOf(Http::Headers::get().GrpcMessage, "fault filter abort"));
+  EXPECT_EQ(nullptr, response->trailers());
+
+  EXPECT_EQ(1UL, test_server_->counter("http.config_test.fault.aborts_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.delays_injected")->value());
   EXPECT_EQ(0UL, test_server_->counter("http.config_test.fault.response_rl_injected")->value());
 }

--- a/test/extensions/filters/http/fault/fault_filter_integration_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_integration_test.cc
@@ -53,9 +53,9 @@ name: fault
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault
   abort:
+    grpc_status: 5
     percentage:
       numerator: 100
-    grpc_status: 5
 )EOF";
 };
 

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -255,6 +255,10 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
       .WillOnce(Return(429));
 
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "429"}, {"content-length", "18"}, {"content-type", "text/plain"}};
   EXPECT_CALL(decoder_filter_callbacks_,
@@ -302,11 +306,118 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
       .WillOnce(Return(429));
 
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "429"}, {"content-length", "18"}, {"content-type", "text/plain"}};
   EXPECT_CALL(decoder_filter_callbacks_,
               encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
   EXPECT_CALL(decoder_filter_callbacks_, encodeData(_, true));
+
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+  Http::MetadataMap metadata_map{{"metadata", "metadata"}};
+  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
+  EXPECT_EQ(1UL, config_->stats().active_faults_.value());
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+  filter_->onDestroy();
+
+  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().active_faults_.value());
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+}
+
+TEST_F(FaultFilterTest, AbortWithGrpcStatus) {
+  decoder_filter_callbacks_.is_grpc_request_ = true;
+
+  envoy::extensions::filters::http::fault::v3::HTTPFault fault;
+  fault.mutable_abort()->mutable_percentage()->set_numerator(100);
+  fault.mutable_abort()->mutable_percentage()->set_denominator(
+      envoy::type::v3::FractionalPercent::HUNDRED);
+  fault.mutable_abort()->set_grpc_status(5);
+  SetUpTest(fault);
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+      .Times(0);
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_,
+              featureEnabled("fault.http.abort.abort_percent",
+                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.grpc_status", 5))
+      .WillOnce(Return(5));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"content-type", "application/grpc"},
+                                                   {"grpc-status", "5"},
+                                                   {"grpc-message", "fault filter abort"}};
+  EXPECT_CALL(decoder_filter_callbacks_,
+              encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+  Http::MetadataMap metadata_map{{"metadata", "metadata"}};
+  EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->decodeMetadata(metadata_map));
+  EXPECT_EQ(1UL, config_->stats().active_faults_.value());
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data_, false));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
+  filter_->onDestroy();
+
+  EXPECT_EQ(0UL, config_->stats().delays_injected_.value());
+  EXPECT_EQ(1UL, config_->stats().aborts_injected_.value());
+  EXPECT_EQ(0UL, config_->stats().active_faults_.value());
+  EXPECT_EQ("fault_filter_abort", decoder_filter_callbacks_.details_);
+}
+
+TEST_F(FaultFilterTest, HeaderAbortWithGrpcStatus) {
+  decoder_filter_callbacks_.is_grpc_request_ = true;
+  SetUpTest(header_abort_only_yaml);
+
+  request_headers_.addCopy("x-envoy-fault-abort-grpc-request", "5");
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.max_active_faults", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
+  EXPECT_CALL(decoder_filter_callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::ResponseFlag::DelayInjected))
+      .Times(0);
+
+  // Abort related calls
+  EXPECT_CALL(runtime_.snapshot_,
+              featureEnabled("fault.http.abort.abort_percent",
+                             Matcher<const envoy::type::v3::FractionalPercent&>(Percent(100))))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.grpc_status", 5))
+      .WillOnce(Return(5));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"},
+                                                   {"content-type", "application/grpc"},
+                                                   {"grpc-status", "5"},
+                                                   {"grpc-message", "fault filter abort"}};
+
+  EXPECT_CALL(decoder_filter_callbacks_,
+              encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
 
   EXPECT_CALL(decoder_filter_callbacks_.stream_info_,
               setResponseFlag(StreamInfo::ResponseFlag::FaultInjected));
@@ -504,6 +615,10 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.cluster.abort.http_status", 503))
       .WillOnce(Return(500));
 
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "500"}, {"content-length", "18"}, {"content-type", "text/plain"}};
   EXPECT_CALL(decoder_filter_callbacks_,
@@ -562,6 +677,10 @@ TEST_F(FaultFilterTest, FixedDelayAndAbort) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
       .WillOnce(Return(503));
 
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
+
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "503"}, {"content-length", "18"}, {"content-type", "text/plain"}};
   EXPECT_CALL(decoder_filter_callbacks_,
@@ -613,6 +732,10 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstreamNodes) {
       .WillOnce(Return(true));
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
       .WillOnce(Return(503));
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
 
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "503"}, {"content-length", "18"}, {"content-type", "text/plain"}};
@@ -679,6 +802,10 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
       .WillOnce(Return(503));
+
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
+      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
 
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "503"}, {"content-length", "18"}, {"content-type", "text/plain"}};
@@ -1096,6 +1223,7 @@ TEST_F(FaultFilterSettingsTest, CheckDefaultRuntimeKeys) {
   EXPECT_EQ("fault.http.abort.abort_percent", settings.abortPercentRuntime());
   EXPECT_EQ("fault.http.delay.fixed_duration_ms", settings.delayDurationRuntime());
   EXPECT_EQ("fault.http.abort.http_status", settings.abortHttpStatusRuntime());
+  EXPECT_EQ("fault.http.abort.grpc_status", settings.abortGrpcStatusRuntime());
   EXPECT_EQ("fault.http.max_active_faults", settings.maxActiveFaultsRuntime());
   EXPECT_EQ("fault.http.rate_limit.response_percent", settings.responseRateLimitPercentRuntime());
 }
@@ -1105,6 +1233,7 @@ TEST_F(FaultFilterSettingsTest, CheckOverrideRuntimeKeys) {
   fault.set_abort_percent_runtime(std::string("fault.abort_percent_runtime"));
   fault.set_delay_percent_runtime(std::string("fault.delay_percent_runtime"));
   fault.set_abort_http_status_runtime(std::string("fault.abort_http_status_runtime"));
+  fault.set_abort_grpc_status_runtime(std::string("fault.abort_grpc_status_runtime"));
   fault.set_delay_duration_runtime(std::string("fault.delay_duration_runtime"));
   fault.set_max_active_faults_runtime(std::string("fault.max_active_faults_runtime"));
   fault.set_response_rate_limit_percent_runtime(
@@ -1116,6 +1245,7 @@ TEST_F(FaultFilterSettingsTest, CheckOverrideRuntimeKeys) {
   EXPECT_EQ("fault.abort_percent_runtime", settings.abortPercentRuntime());
   EXPECT_EQ("fault.delay_duration_runtime", settings.delayDurationRuntime());
   EXPECT_EQ("fault.abort_http_status_runtime", settings.abortHttpStatusRuntime());
+  EXPECT_EQ("fault.abort_grpc_status_runtime", settings.abortGrpcStatusRuntime());
   EXPECT_EQ("fault.max_active_faults_runtime", settings.maxActiveFaultsRuntime());
   EXPECT_EQ("fault.response_rate_limit_percent_runtime",
             settings.responseRateLimitPercentRuntime());

--- a/test/extensions/filters/http/fault/fault_filter_test.cc
+++ b/test/extensions/filters/http/fault/fault_filter_test.cc
@@ -255,10 +255,6 @@ TEST_F(FaultFilterTest, AbortWithHttpStatus) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
       .WillOnce(Return(429));
 
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
-      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
-
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "429"}, {"content-length", "18"}, {"content-type", "text/plain"}};
   EXPECT_CALL(decoder_filter_callbacks_,
@@ -305,10 +301,6 @@ TEST_F(FaultFilterTest, HeaderAbortWithHttpStatus) {
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 429))
       .WillOnce(Return(429));
-
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
-      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
 
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "429"}, {"content-length", "18"}, {"content-type", "text/plain"}};
@@ -615,10 +607,6 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstream) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.cluster.abort.http_status", 503))
       .WillOnce(Return(500));
 
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
-      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
-
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "500"}, {"content-length", "18"}, {"content-type", "text/plain"}};
   EXPECT_CALL(decoder_filter_callbacks_,
@@ -677,10 +665,6 @@ TEST_F(FaultFilterTest, FixedDelayAndAbort) {
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
       .WillOnce(Return(503));
 
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
-      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
-
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "503"}, {"content-length", "18"}, {"content-type", "text/plain"}};
   EXPECT_CALL(decoder_filter_callbacks_,
@@ -732,10 +716,6 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortDownstreamNodes) {
       .WillOnce(Return(true));
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
       .WillOnce(Return(503));
-
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
-      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
 
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "503"}, {"content-length", "18"}, {"content-type", "text/plain"}};
@@ -802,10 +782,6 @@ TEST_F(FaultFilterTest, FixedDelayAndAbortHeaderMatchSuccess) {
 
   EXPECT_CALL(runtime_.snapshot_, getInteger("fault.http.abort.http_status", 503))
       .WillOnce(Return(503));
-
-  EXPECT_CALL(runtime_.snapshot_,
-              getInteger("fault.http.abort.grpc_status", std::numeric_limits<uint64_t>::max()))
-      .WillOnce(Return(std::numeric_limits<uint64_t>::max()));
 
   Http::TestResponseHeaderMapImpl response_headers{
       {":status", "503"}, {"content-length", "18"}, {"content-type", "text/plain"}};


### PR DESCRIPTION
This change adds a feature to set "grpc_status" code explicitly via config or header instead of using http_status to derive its value.

More details about why this change is required
https://github.com/envoyproxy/envoy/issues/10323

Description:
Risk Level: Low
Testing: Added unit and integration tests
Docs Changes: Added
Release Notes: Added

- [x] Unit testing

- [x] Integration testing

- [x] Documentation update
